### PR TITLE
feat: add smithery yaml for configuration

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,14 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: http
+  configSchema:
+    type: object
+    description: Configuration for Context Awesome MCP server
+    properties:
+      CONTEXT_AWESOME_API_HOST:
+        type: string
+        description: "API host for the Context Awesome backend (default: https://api.context-awesome.com)"
+        default: "https://api.context-awesome.com"
+  exampleConfig:
+    CONTEXT_AWESOME_API_HOST: "https://api.context-awesome.com"


### PR DESCRIPTION
This pull request introduces a new `smithery.yaml` configuration file to the project. The file defines the start command configuration schema for the Context Awesome MCP server, including documentation and an example configuration.

Configuration management:

* Added a `smithery.yaml` file specifying the `startCommand` as an HTTP type, with a configuration schema for the `CONTEXT_AWESOME_API_HOST` parameter, including a default value and description.