### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Navigate to Settings > Connectors > Add Custom Connector. Enter:
 
 See [Additional Installation Methods](#additional-installation-methods) for other MCP clients.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/bh-rat-context-awesome).
+
 ## Local Setup
 
 For development or self-hosting:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/bh-rat-context-awesome).