### PR TITLE
chore: add LICENSE and publish metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bharat Geleda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -34,8 +34,16 @@
     "documentation",
     "cli"
   ],
-  "author": "",
+  "author": "Bharat Geleda <bharatgeleda@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bh-rat/context-awesome.git"
+  },
+  "homepage": "https://github.com/bh-rat/context-awesome#readme",
+  "bugs": {
+    "url": "https://github.com/bh-rat/context-awesome/issues"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "commander": "^12.0.0",


### PR DESCRIPTION
## Summary

- Add MIT `LICENSE` file. `package.json` already declared `license: "MIT"` and listed `LICENSE` under `files`, but the file was missing on disk — npm pack was silently dropping it. With this change, the license text actually ships in the tarball.
- Fill `author`, `repository`, `homepage`, `bugs` in `package.json` so the npm page shows proper GitHub / issues links.

Prep for the first `npm publish` of `context-awesome`.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm pack --dry-run` includes `LICENSE` (31 files, was 30)
- [x] Unpacked tarball still excludes `skills/`, source, tests, configs — only `build/`, `LICENSE`, `README.md`, `package.json`
- [ ] After merge + `npm login`, first publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)