### PR TITLE
chore: bump version from 1.0.0 to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-awesome",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-awesome",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-awesome",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "CLI + MCP server for curated awesome-list context",
   "main": "build/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
   "name": "io.github.bh-rat/context-awesome",
   "description": "MCP server for accessing curated awesome list documentation",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ const program = new Command();
 program
   .name("context-awesome")
   .description("CLI for querying curated awesome-list context")
-  .version("1.0.0")
+  .version("0.1.0")
   .addHelpText(
     "after",
     `

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { createServerInstance } from "./mcp-server.js";
 
-const SERVER_VERSION = "1.0.0";
+const SERVER_VERSION = "0.1.0";
 const DEFAULT_PORT = 3000;
 const DEFAULT_API_HOST =
   process.env.AWESOME_CONTEXT_API_HOST ||

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -16,7 +16,7 @@ export function createServerInstance(config: ServerConfig): McpServer {
   const apiClient = new AwesomeContextAPIClient(config.apiHost, config.apiKey, !!config.debug);
 
   const server = new McpServer(
-    { name: "context-awesome", version: "1.0.0" },
+    { name: "context-awesome", version: "0.1.0" },
     {
       instructions:
         "Use this server to search and retrieve curated awesome lists. Prefer `find_awesome_section` when you want a whole section, `search_awesome_items` for individual tools/resources, and `get_awesome_items` to fetch items from a known list/section.",


### PR DESCRIPTION
## Summary

Reset the version from `1.0.0` to `0.1.0` before the first npm publish.

Starting at `1.0.0` commits the package to SemVer's stability contract (breaking changes require a major bump) before the API has had any real use. `0.1.0` signals that the surface is still young — callers can expect churn between minor releases — and lets us iterate freely until the tool shape feels settled. Bump to `1.0.0` later when that's true.

Bumped in five places so the CLI `--version`, the MCP server handshake, the `server.json` manifest, and the package metadata all agree:

- `package.json`
- `server.json`
- `src/index.ts` (`SERVER_VERSION`)
- `src/cli.ts` (`.version(...)`)
- `src/mcp-server.ts` (`McpServer` constructor)

`package-lock.json` resynced via `npm install`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` passes 5/5
- [x] `npm run format:check` clean
- [ ] After merge: `npm publish` publishes `context-awesome@0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)