### PR TITLE
chore: prepare context-awesome for MCP registry publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "context-awesome",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "mcpName": "io.github.bh-rat/context-awesome",
   "description": "CLI + MCP server for curated awesome-list context",
   "main": "build/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,12 +1,28 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.bh-rat/context-awesome",
+  "title": "Context Awesome",
   "description": "MCP server for accessing curated awesome list documentation",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "websiteUrl": "https://www.context-awesome.com",
+  "repository": {
+    "url": "https://github.com/bh-rat/context-awesome",
+    "source": "github"
+  },
   "remotes": [
     {
       "type": "streamable-http",
       "url": "https://www.context-awesome.com/api/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "context-awesome",
+      "version": "0.1.1",
+      "transport": {
+        "type": "stdio"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `mcpName: "io.github.bh-rat/context-awesome"` to `package.json` — required by the MCP registry to verify npm package ownership
- Bump version `0.1.0` → `0.1.1` so the new field is present in the published npm artifact
- Update `server.json` schema URL to the current `2025-12-11` version
- Add `title`, `websiteUrl`, and `repository` fields to `server.json`
- Add `packages` entry (npm/stdio) alongside existing `remotes` entry so registry clients can choose between the hosted URL or local binary

## After merging

```bash
# Rebuild and publish npm package (picks up mcpName)
npm run build && npm publish --access public

# Install publisher CLI if needed
brew install mcp-publisher

# Authenticate and publish to MCP registry
mcp-publisher login github
mcp-publisher publish

# Verify
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.bh-rat/context-awesome"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)